### PR TITLE
Supports the 0.8.0 beta versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/taion/graphql-type-json#readme",
   "peerDependencies": {
-    "graphql": ">=0.4.0"
+    "graphql": ">=0.4.0 || ^0.8.0-b"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
The authors of graphql decided to include a beta version with "-b" suffix in their version number since 0.8.0.
Added the support for -b only for version 0.8.0 only (its the only version that includes beta releases, we dont know if this is going to happen in the future or not, but currently all the stack - graphiql,graphql-relay,etc- support this).