### PR TITLE
Add support for variables in JSON subfields

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ function identity(value) {
   return value;
 }
 
-function parseLiteral(ast) {
+function parseLiteral(ast, variables) {
   switch (ast.kind) {
     case Kind.STRING:
     case Kind.BOOLEAN:
@@ -15,16 +15,20 @@ function parseLiteral(ast) {
       return parseFloat(ast.value);
     case Kind.OBJECT: {
       const value = Object.create(null);
-      ast.fields.forEach((field) => {
-        value[field.name.value] = parseLiteral(field.value);
+      ast.fields.forEach(field => {
+        value[field.name.value] = parseLiteral(field.value, variables);
       });
 
       return value;
     }
     case Kind.LIST:
-      return ast.values.map(parseLiteral);
+      return ast.values.map(n => parseLiteral(n, variables));
     case Kind.NULL:
       return null;
+    case Kind.VARIABLE: {
+      const name = ast.name.value;
+      return variables ? variables[name] : undefined;
+    }
     default:
       return undefined;
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-import { graphql, GraphQLObjectType, GraphQLSchema } from 'graphql';
+import { graphql, GraphQLInt, GraphQLObjectType, GraphQLSchema } from 'graphql';
 
 import GraphQLJSON from '../src';
 
@@ -46,6 +46,7 @@ describe('GraphQLJSON', () => {
           },
         },
       }),
+      types: [GraphQLInt],
     });
   });
 
@@ -59,7 +60,7 @@ describe('GraphQLJSON', () => {
     it('should support parsing values', () =>
       graphql(
         schema,
-        'query ($arg: JSON) { value(arg: $arg) }',
+        'query ($arg: JSON!) { value(arg: $arg) }',
         null,
         null,
         { arg: FIXTURE },
@@ -72,17 +73,17 @@ describe('GraphQLJSON', () => {
   describe('parseLiteral', () => {
     it('should support parsing literals', () =>
       graphql(schema, `
-        {
+        query ($intValue: Int = 3) {
           value(arg: {
             string: "string",
-            int: 3,
+            int: $intValue,
             float: 3.14,
             true: true,
             false: false,
             null: null,
             object: {
               string: "string",
-              int: 3,
+              int: $intValue,
               float: 3.14,
               true: true,
               false: false,
@@ -90,7 +91,7 @@ describe('GraphQLJSON', () => {
             },
             array: [
               "string",
-              3,
+              $intValue,
               3.14,
               true,
               false,


### PR DESCRIPTION
In the following GraphQL schema:

```graphql
scalar JSON

type Query {
  jsonIssue(input: JSON): JSON
}
```

it's possible to run the following GraphQL query:

```graphql
query Foo($myVal: String = "bar") {
  jsonIssue(input: { subfield: $myVal })
}
```

Note that the user was referencing a variable in a subfield of the JSON.

Within `parseLiteral` of the custom scalar we can see the variable reference as an AST node:

```js
{ kind: 'Variable',
  name: { kind: 'Name', value: 'myVal', loc: { start: 81, end: 86 } },
  loc: { start: 80, end: 86 } }
```

It turns out that `parseLiteral` takes two argument, the second being variables so that we can reconstruct the value.

---

Here's a full code example demonstrating the issue with the existing implementation (requires Node 8.6+):

```js
const {
  GraphQLSchema,
  GraphQLObjectType,
  GraphQLScalarType,
  graphql,
} = require("graphql");
const { Kind } = require("graphql/language");

function identity(value) {
  return value;
}

function parseLiteral(ast) {
  switch (ast.kind) {
    case Kind.STRING:
    case Kind.BOOLEAN:
      return ast.value;
    case Kind.INT:
    case Kind.FLOAT:
      return parseFloat(ast.value);
    case Kind.OBJECT: {
      const value = Object.create(null);
      ast.fields.forEach(field => {
        value[field.name.value] = parseLiteral(field.value);
      });

      return value;
    }
    case Kind.LIST:
      return ast.values.map(parseLiteral);
    case Kind.NULL:
      return null;
    default:
      console.log(ast); // <<<<<<<<<<<<<<<<
      return undefined;
  }
}

const GraphQLJSON = new GraphQLScalarType({
  name: "JSON",
  description:
    "The `JSON` scalar type represents JSON values as specified by " +
    "[ECMA-404](http://www.ecma-international.org/" +
    "publications/files/ECMA-ST/ECMA-404.pdf).",
  serialize: identity,
  parseValue: identity,
  parseLiteral,
});

const schema = new GraphQLSchema({
  query: new GraphQLObjectType({
    name: "Query",
    fields: {
      jsonIssue: {
        type: GraphQLJSON,
        args: {
          input: {
            type: GraphQLJSON,
          },
        },
        resolve(parent, args, context, info) {
          return args.input;
        },
      },
    },
  }),
});

(async () => {
  const result = await graphql(
    schema,
    `
      query Foo($myVal: String = "bar") {
        jsonIssue(input: { subfield: $myVal })
      }
    `
  );
  console.dir(result);
})().then(null, e => {
  console.error(e);
  process.exit(1);
});
```

Outputs:

```
{ kind: 'Variable',
  name: { kind: 'Name', value: 'myVal', loc: { start: 81, end: 86 } },
  loc: { start: 80, end: 86 } }
{ kind: 'Variable',
  name: { kind: 'Name', value: 'myVal', loc: { start: 81, end: 86 } },
  loc: { start: 80, end: 86 } }
{ data: { jsonIssue: { subfield: undefined } } }
```

Note that in the output we get `subfield: undefined` rather than `subfield: "bar"` as expected.

This PR fixes this issue. This issue was discovered by a PostGraphile user: https://github.com/graphile-contrib/postgraphile-plugin-connection-filter/issues/33

Thanks for this module! 🙏 